### PR TITLE
Check for forwarded protocol

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rack-canonical-header (1.0.2)
+    rack-canonical-header (1.0.3)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/rack-canonical-header/middleware.rb
+++ b/lib/rack-canonical-header/middleware.rb
@@ -16,7 +16,8 @@ module Canonical
     end
 
     def self.canonical_tag(env, canonical_host)
-      canonical = "#{env['rack.url_scheme']}://#{canonical_host}#{env['ORIGINAL_FULLPATH']}"
+      url_scheme = env['HTTP_X_FORWARDED_PROTO'] || env['rack.url_scheme']
+      canonical = "#{url_scheme}://#{canonical_host}#{env['ORIGINAL_FULLPATH']}"
       "<#{canonical}>; rel=\"canonical\""
     end
 

--- a/lib/rack-canonical-header/version.rb
+++ b/lib/rack-canonical-header/version.rb
@@ -1,3 +1,3 @@
 module Canonical
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.0.3'.freeze
 end


### PR DESCRIPTION
On Heroku, the url_scheme is always http. Checking for the forwarded protocol fixes this error